### PR TITLE
Switch to @vechain/sdk

### DIFF
--- a/deploy/MyToken/00_deploy.ts
+++ b/deploy/MyToken/00_deploy.ts
@@ -1,14 +1,20 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { DeployFunction } from 'hardhat-deploy/types';
-import { type MyToken } from '../../typechain-types';
+import type { DeployFunction } from 'hardhat-deploy/types';
+import type { MyToken } from '../../typechain-types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    // get access to your named accounts, check hardhat.config.ts on your configuration
     const { deployer, owner } = await hre.getNamedAccounts();
+
+    // deploy a contract, it will automatically deploy again when the code changes
     await hre.deployments.deploy('MyToken', {
         from: deployer
     })
 
+    // get an ethers instance for interaction with the contract
     const contract = await hre.ethers.getContract('MyToken') as MyToken;
+
+    // example for reading and changing data
     const currentOwner = await contract.owner()
     if (currentOwner !== owner) {
         console.log('Transferring Ownership to', owner)

--- a/deploy/MyToken/00_deploy.ts
+++ b/deploy/MyToken/00_deploy.ts
@@ -1,11 +1,20 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
+import { type MyToken } from '../../typechain-types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-    const { deployer } = await hre.getNamedAccounts();
+    const { deployer, owner } = await hre.getNamedAccounts();
     await hre.deployments.deploy('MyToken', {
         from: deployer
     })
+
+    const contract = await hre.ethers.getContract('MyToken') as MyToken;
+    const currentOwner = await contract.owner()
+    if (currentOwner !== owner) {
+        console.log('Transferring Ownership to', owner)
+        await contract.transferOwnership(owner)
+    }
+
 };
 
 func.id = 'mytoken'; // name your deployment

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -12,36 +12,35 @@ yarn add --dev hardhat
 npx hardhat init
 
 # Init Vechain
-yarn add --dev @vechain/web3-providers-connex @vechain/hardhat-vechain @vechain/hardhat-web3 @vechain/hardhat-ethers
+yarn add --dev @vechain/sdk-hardhat-plugin
 
 # Init Dependencies & Helpers
 yarn add @openzeppelin/contracts@4 @openzeppelin/contracts-upgradeable@4 @openzeppelin/hardhat-upgrades @ensdomains/ens-contracts
-yarn add --dev dotenv @dotenvx/dotenvx hardhat-deploy@npm:@vechain.energy/hardhat-deploy@latest
+yarn add --dev dotenv @dotenvx/dotenvx
+yarn add --dev @nomicfoundation/hardhat-ethers ethers hardhat-deploy hardhat-deploy-ethers
 ```
 
 ```ts
 import "@nomicfoundation/hardhat-toolbox";
-import "@openzeppelin/hardhat-upgrades";
-import "@vechain/hardhat-vechain";
-import "@vechain/hardhat-ethers";
-import "hardhat-deploy";
-import "dotenv/config";
+import '@nomicfoundation/hardhat-ethers';
+import '@vechain/sdk-hardhat-plugin';
+import '@openzeppelin/hardhat-upgrades';
+import 'hardhat-deploy';
+import 'hardhat-deploy-ethers';
+import 'dotenv/config';
 
-const PRIVATE_KEY = process.env.PRIVATE_KEY;
-
-if (!PRIVATE_KEY) {
-  throw new Error(
-    "Please set your PRIVATE_KEY in a .env file or in your environment variables"
-  );
+if (!process.env.PRIVATE_KEY) {
+  throw new Error('Please set your PRIVATE_KEY in a .env file or in your environment variables');
 }
 
 const accounts = [
-  PRIVATE_KEY, // deployer
-  process.env.DEPLOYER_PRIVATE_KEY ?? PRIVATE_KEY, // proxyOwner
-  process.env.OWNER_PRIVATE_KEY ?? PRIVATE_KEY, // owner
+  process.env.PRIVATE_KEY, // deployer
+  process.env.DEPLOYER_PRIVATE_KEY ?? process.env.PRIVATE_KEY, // proxyOwner
+  process.env.OWNER_PRIVATE_KEY ?? process.env.PRIVATE_KEY, // owner
 ];
 
 // see https://github.com/wighawag/hardhat-deploy?tab=readme-ov-file#1-namedaccounts-ability-to-name-addresses
+// references the index from the accounts list above, can be configured by network too
 const namedAccounts = {
   deployer: { default: 0 },
   proxyOwner: { default: 1 },
@@ -54,30 +53,34 @@ const config = {
   networks: {
     hardhat: {
       chainId: 1337,
-      gas: 10000000,
+      gas: 10000000
     },
     vechain_testnet: {
       url: "https://node-testnet.vechain.energy",
       accounts,
       restful: true,
-      gas: 10000000,
+      gas: 'auto',
+      gasPrice: 'auto',
+      gasMultiplier: 1,
 
       // optionally use fee delegation to let someone else pay the gas fees
       // visit vechain.energy for a public fee delegation service
-      delegate: {
-        url: "https://sponsor-testnet.vechain.energy/by/90",
+      delegator: {
+        delegatorUrl: "https://sponsor-testnet.vechain.energy/by/90"
       },
+      enableDelegation: true,
       loggingEnabled: true,
     },
     vechain_mainnet: {
       url: "https://node-mainnet.vechain.energy",
       accounts,
       restful: true,
-      gas: 10000000,
+      gas: 'auto',
+      gasPrice: 'auto',
+      gasMultiplier: 1,
     },
   },
-
-  namedAccounts,
+  namedAccounts
 };
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,13 +1,9 @@
-import { task } from 'hardhat/config';
 import "@nomicfoundation/hardhat-toolbox";
+import '@nomicfoundation/hardhat-ethers';
 import '@vechain/sdk-hardhat-plugin';
 import '@openzeppelin/hardhat-upgrades';
 import 'hardhat-deploy';
-
-import '@nomicfoundation/hardhat-ethers';
-import 'hardhat-deploy';
 import 'hardhat-deploy-ethers';
-
 import 'dotenv/config';
 
 if (!process.env.PRIVATE_KEY) {
@@ -27,10 +23,6 @@ const namedAccounts = {
   proxyOwner: { default: 1 },
   owner: { default: 2 },
 };
-
-task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
-  console.log(await hre.network.provider.request({ method: 'eth_accounts' }));
-});
 
 const config = {
   solidity: "0.8.19",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,8 +1,13 @@
+import { task } from 'hardhat/config';
 import "@nomicfoundation/hardhat-toolbox";
+import '@vechain/sdk-hardhat-plugin';
 import '@openzeppelin/hardhat-upgrades';
-import "@vechain/hardhat-vechain";
-import '@vechain/hardhat-ethers';
 import 'hardhat-deploy';
+
+import '@nomicfoundation/hardhat-ethers';
+import 'hardhat-deploy';
+import 'hardhat-deploy-ethers';
+
 import 'dotenv/config';
 
 if (!process.env.PRIVATE_KEY) {
@@ -23,6 +28,10 @@ const namedAccounts = {
   owner: { default: 2 },
 };
 
+task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
+  console.log(await hre.network.provider.request({ method: 'eth_accounts' }));
+});
+
 const config = {
   solidity: "0.8.19",
   defaultNetwork: "hardhat",
@@ -35,20 +44,25 @@ const config = {
       url: "https://node-testnet.vechain.energy",
       accounts,
       restful: true,
-      gas: 10000000,
+      gas: 'auto',
+      gasPrice: 'auto',
+      gasMultiplier: 1,
 
       // optionally use fee delegation to let someone else pay the gas fees
       // visit vechain.energy for a public fee delegation service
-      delegate: {
-        url: "https://sponsor-testnet.vechain.energy/by/90"
+      delegator: {
+        delegatorUrl: "https://sponsor-testnet.vechain.energy/by/90"
       },
+      enableDelegation: true,
       loggingEnabled: true,
     },
     vechain_mainnet: {
       url: "https://node-mainnet.vechain.energy",
       accounts,
       restful: true,
-      gas: 10000000,
+      gas: 'auto',
+      gasPrice: 'auto',
+      gasMultiplier: 1,
     },
   },
   namedAccounts

--- a/package.json
+++ b/package.json
@@ -15,14 +15,11 @@
     "@types/chai": "^4.2.0",
     "@types/mocha": ">=9.1.0",
     "@types/node": ">=16.0.0",
-    "@vechain/hardhat-ethers": "^0.1.6",
-    "@vechain/hardhat-vechain": "^0.1.7",
-    "@vechain/hardhat-web3": "^0.1.4",
-    "@vechain/web3-providers-connex": "^1.1.2",
+    "@vechain/sdk-hardhat-plugin": "^1.0.0-beta.10",
     "chai": "^4.2.0",
     "ethers": "^6.4.0",
     "hardhat": "^2.19.4",
-    "hardhat-deploy": "npm:@vechain.energy/hardhat-deploy@latest",
+    "hardhat-deploy": "^0.12.4",
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.8.0",
     "ts-node": ">=8.0.0",
@@ -33,7 +30,8 @@
     "@openzeppelin/contracts": "4",
     "@openzeppelin/contracts-upgradeable": "4",
     "@openzeppelin/hardhat-upgrades": "^3.0.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "hardhat-deploy-ethers": "^0.4.2"
   },
   "scripts": {
     "build": "hardhat compile",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adraffy/ens-normalize@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@adraffy/ens-normalize@npm:1.10.1"
+  checksum: 0836f394ea256972ec19a0b5e78cb7f5bcdfd48d8a32c7478afc94dd53ae44c04d1aa2303d7f3077b4f3ac2323b1f557ab9188e8059978748fdcd83e04a80dcc
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/sha256-js@npm:1.2.2":
   version: 1.2.2
   resolution: "@aws-crypto/sha256-js@npm:1.2.2"
@@ -188,6 +195,15 @@ __metadata:
   bin:
     rlp: bin/rlp
   checksum: 30db19c78faa2b6ff27275ab767646929207bb207f903f09eb3e4c273ce2738b45f3c82169ddacd67468b4f063d8d96035f2bf36f02b6b7e4d928eefe2e3ecbc
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/rlp@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@ethereumjs/rlp@npm:5.0.2"
+  bin:
+    rlp: bin/rlp.cjs
+  checksum: b569061ddb1f4cf56a82f7a677c735ba37f9e94e2bbaf567404beb9e2da7aa1f595e72fc12a17c61f7aec67fd5448443efe542967c685a2fe0ffc435793dcbab
   languageName: node
   linkType: hard
 
@@ -810,6 +826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/ciphers@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "@noble/ciphers@npm:0.5.3"
+  checksum: c5ed5d7d43b054c2051b3e0e220353cc9d31fa8d17b82cfb753d87f922e4e1e69b73ca5273a9cc457023f83d96d1d9a51678d2f6d4e58ca039d1111a62856d19
+  languageName: node
+  linkType: hard
+
 "@noble/curves@npm:1.1.0, @noble/curves@npm:~1.1.0":
   version: 1.1.0
   resolution: "@noble/curves@npm:1.1.0"
@@ -825,6 +848,15 @@ __metadata:
   dependencies:
     "@noble/hashes": 1.3.2
   checksum: bb798d7a66d8e43789e93bc3c2ddff91a1e19fdb79a99b86cd98f1e5eff0ee2024a2672902c2576ef3577b6f282f3b5c778bebd55761ddbb30e36bf275e83dd0
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:~1.4.0":
+  version: 1.4.0
+  resolution: "@noble/curves@npm:1.4.0"
+  dependencies:
+    "@noble/hashes": 1.4.0
+  checksum: 0014ff561d16e98da4a57e2310a4015e4bdab3b1e1eafcd18d3f9b955c29c3501452ca5d702fddf8ca92d570bbeadfbe53fe16ebbd81a319c414f739154bb26b
   languageName: node
   linkType: hard
 
@@ -846,6 +878,13 @@ __metadata:
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.4.0, @noble/hashes@npm:~1.4.0":
+  version: 1.4.0
+  resolution: "@noble/hashes@npm:1.4.0"
+  checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
   languageName: node
   linkType: hard
 
@@ -1386,6 +1425,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:~1.1.6":
+  version: 1.1.6
+  resolution: "@scure/base@npm:1.1.6"
+  checksum: d6deaae91deba99e87939af9e55d80edba302674983f32bba57f942e22b1726a83c62dc50d8f4370a5d5d35a212dda167fb169f4b0d0c297488d8604608fc3d3
+  languageName: node
+  linkType: hard
+
 "@scure/bip32@npm:1.1.5":
   version: 1.1.5
   resolution: "@scure/bip32@npm:1.1.5"
@@ -1408,6 +1454,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/bip32@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@scure/bip32@npm:1.4.0"
+  dependencies:
+    "@noble/curves": ~1.4.0
+    "@noble/hashes": ~1.4.0
+    "@scure/base": ~1.1.6
+  checksum: eff491651cbf2bea8784936de75af5fc020fc1bbb9bcb26b2cfeefbd1fb2440ebfaf30c0733ca11c0ae1e272a2ef4c3c34ba5c9fb3e1091c3285a4272045b0c6
+  languageName: node
+  linkType: hard
+
 "@scure/bip39@npm:1.1.1":
   version: 1.1.1
   resolution: "@scure/bip39@npm:1.1.1"
@@ -1425,6 +1482,16 @@ __metadata:
     "@noble/hashes": ~1.3.0
     "@scure/base": ~1.1.0
   checksum: c5bd6f1328fdbeae2dcdd891825b1610225310e5e62a4942714db51066866e4f7bef242c7b06a1b9dcc8043a4a13412cf5c5df76d3b10aa9e36b82e9b6e3eeaa
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@scure/bip39@npm:1.3.0"
+  dependencies:
+    "@noble/hashes": ~1.4.0
+    "@scure/base": ~1.1.6
+  checksum: dbb0b27df753eb6c6380010b25cc9a9ea31f9cb08864fc51e69e5880ff7e2b8f85b72caea1f1f28af165e83b72c48dd38617e43fc632779d025b50ba32ea759e
   languageName: node
   linkType: hard
 
@@ -1609,21 +1676,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/bn.js@npm:*, @types/bn.js@npm:^5.1.0":
+  version: 5.1.5
+  resolution: "@types/bn.js@npm:5.1.5"
+  dependencies:
+    "@types/node": "*"
+  checksum: c87b28c4af74545624f8a3dae5294b16aa190c222626e8d4b2e327b33b1a3f1eeb43e7a24d914a9774bca43d8cd6e1cb0325c1f4b3a244af6693a024e1d918e6
+  languageName: node
+  linkType: hard
+
 "@types/bn.js@npm:^4.11.3":
   version: 4.11.6
   resolution: "@types/bn.js@npm:4.11.6"
   dependencies:
     "@types/node": "*"
   checksum: 7f66f2c7b7b9303b3205a57184261974b114495736b77853af5b18d857c0b33e82ce7146911e86e87a87837de8acae28986716fd381ac7c301fd6e8d8b6c811f
-  languageName: node
-  linkType: hard
-
-"@types/bn.js@npm:^5.1.0":
-  version: 5.1.5
-  resolution: "@types/bn.js@npm:5.1.5"
-  dependencies:
-    "@types/node": "*"
-  checksum: c87b28c4af74545624f8a3dae5294b16aa190c222626e8d4b2e327b33b1a3f1eeb43e7a24d914a9774bca43d8cd6e1cb0325c1f4b3a244af6693a024e1d918e6
   languageName: node
   linkType: hard
 
@@ -1649,6 +1716,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 7d211e74331affd3578b5469244f5cef84a93775f38332adb3ef12413559a23862bc682c6873d0a404b01c9d5d5f7d3ae091fe835b435b633eb420e3055b3e56
+  languageName: node
+  linkType: hard
+
+"@types/elliptic@npm:^6.4.18":
+  version: 6.4.18
+  resolution: "@types/elliptic@npm:6.4.18"
+  dependencies:
+    "@types/bn.js": "*"
+  checksum: c27613c530fb95441e5e6b456c8c9bc26568ca14c546aae6d7c1d8d46869f79a2272feaef266ac00bdb68b2671e6351ed01b91b82266eac30ca9092720825d16
   languageName: node
   linkType: hard
 
@@ -1726,7 +1802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^10.0.3, @types/node@npm:^10.3.2":
+"@types/node@npm:^10.0.3":
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
   checksum: 2cdb3a77d071ba8513e5e8306fa64bf50e3c3302390feeaeff1fd325dd25c8441369715dfc8e3701011a72fed5958c7dfa94eb9239a81b3c286caa4d97db6eef
@@ -1814,114 +1890,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vechain/connex-driver@npm:^2.0.12":
-  version: 2.1.0
-  resolution: "@vechain/connex-driver@npm:2.1.0"
+"@types/ws@npm:^8.5.10":
+  version: 8.5.10
+  resolution: "@types/ws@npm:8.5.10"
   dependencies:
-    "@vechain/connex-types": ^2.1.0
-    axios: ^0.21.1
-    bignumber.js: ^7.2.1
-    isomorphic-ws: ^4.0.1
-    lru-cache: ^5.1.1
-    thor-devkit: ^2.0.5
-    ws: ^7.1.0
-  checksum: 3c80609c5ef4e1776f7b3801ea3f05e79b330b3e0d69777a787df23270db1435f4dc4b12ba452f92ec55b4f4b75ac306f47fff5e0725ace3b7b930a5258d778a
+    "@types/node": "*"
+  checksum: 3ec416ea2be24042ebd677932a462cf16d2080393d8d7d0b1b3f5d6eaa4a7387aaf0eefb99193c0bfd29444857cf2e0c3ac89899e130550dc6c14ada8a46d25e
   languageName: node
   linkType: hard
 
-"@vechain/connex-framework@npm:^2.0.12":
-  version: 2.1.0
-  resolution: "@vechain/connex-framework@npm:2.1.0"
+"@vechain/sdk-core@npm:1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-core@npm:1.0.0-beta.10"
   dependencies:
-    "@vechain/connex-types": ^2.1.0
-    bignumber.js: ^7.2.1
-    thor-devkit: ^2.0.5
-    validator-ts: ^0.9.1
-  checksum: cec6d0b76162054169494f28939d0c97201bf0839bb875cb8cccf978758e3285a65c2ee4ebec6bb8cbd5fab6be530861620577fbfb712fd3c586b210999182bf
+    "@ethereumjs/rlp": ^5.0.2
+    "@noble/ciphers": ^0.5.2
+    "@scure/bip32": ^1.4.0
+    "@scure/bip39": ^1.3.0
+    "@types/elliptic": ^6.4.18
+    "@vechain/sdk-errors": 1.0.0-beta.10
+    "@vechain/sdk-logging": 1.0.0-beta.10
+    bignumber.js: ^9.1.2
+    blakejs: ^1.2.1
+    elliptic: ^6.5.5
+    ethers: 6.12.1
+    fast-json-stable-stringify: ^2.1.0
+  checksum: 55f80dbd92a03ebfd476bc2805d36829189680ba9e6bfd1e325c91018ff4bbc973353b83b3186b8d7c3abe8547b3fcc1dfc997dd8d8dc46239faf853c790db61
   languageName: node
   linkType: hard
 
-"@vechain/connex-types@npm:^2.0.2, @vechain/connex-types@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@vechain/connex-types@npm:2.1.0"
-  checksum: ebb380c586d41fac9fed617fc7b6d7e0886dc7d222041cd07ecc0679c033a146a40416e1c2d7bdafd95b4512cfdf9d79e6ab8dd625afcc4f32fe7a09c3e40705
+"@vechain/sdk-errors@npm:1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-errors@npm:1.0.0-beta.10"
+  checksum: 98597d184e035ecefbaf530af59f30cff64cb475ae0ae1de6a258a6744686e3c9bcc4c5d08cd878e6043dadfcdabfa8e384c3beaa0bff0cb3dce44fbdc2f4fc0
   languageName: node
   linkType: hard
 
-"@vechain/ethers@npm:^4.0.27-5":
-  version: 4.0.27-5
-  resolution: "@vechain/ethers@npm:4.0.27-5"
+"@vechain/sdk-ethers-adapter@npm:1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-ethers-adapter@npm:1.0.0-beta.10"
   dependencies:
-    "@types/node": ^10.3.2
-    aes-js: 3.0.0
-    bn.js: ^4.4.0
-    elliptic: 6.5.4
-    hash.js: 1.1.3
-    js-sha3: 0.5.7
-    scrypt-js: 2.0.4
-    setimmediate: 1.0.4
-    uuid: 2.0.1
-    xmlhttprequest: 1.8.0
-  checksum: 896737360e8e34febc89a84c2c87170ba6af593b059c6f751175f6719661c4bd84960b1323677d056ee024633e8ddd6a72683b38346958bedd7ae8614f8f52c6
+    "@vechain/sdk-core": 1.0.0-beta.10
+    "@vechain/sdk-network": 1.0.0-beta.10
+  checksum: c0a17cd8eef6977f7c807d11104c0fa0a614f2e4200abe2055bbdf91a403066e496fc52300d5a7d6533e6b478bab7487684cbd154c4053569b19be39d36a7ac9
   languageName: node
   linkType: hard
 
-"@vechain/hardhat-ethers@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "@vechain/hardhat-ethers@npm:0.1.6"
+"@vechain/sdk-hardhat-plugin@npm:^1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-hardhat-plugin@npm:1.0.0-beta.10"
   dependencies:
-    ethers: ^6.7.1
-  peerDependencies:
-    "@nomicfoundation/hardhat-ethers": ^3.0.4
-    "@vechain/hardhat-vechain": ^0.1.5
-    "@vechain/web3-providers-connex": ^1.1.2
-    ethers: ^6.7.1
-    hardhat: ^2.12.7
-  checksum: 3560ee29202b414ef00b8cb39b4fa2ac4e4878f065502f87c0c74d992afe21ad4f178cfb550fa91a43531a9b22bb6c6672831fff5bdf068354fee0da7f2d09eb
+    "@vechain/sdk-ethers-adapter": 1.0.0-beta.10
+    "@vechain/sdk-network": 1.0.0-beta.10
+  checksum: b32fc03887c193b15873d4dc4782b2a7216d4bd8fca2a0a693f6907bb7331848fc0448e2cf5b50d8bc5117fffe04d2ebe47b16b290876e72c87cba5ea54d8867
   languageName: node
   linkType: hard
 
-"@vechain/hardhat-vechain@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "@vechain/hardhat-vechain@npm:0.1.7"
+"@vechain/sdk-logging@npm:1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-logging@npm:1.0.0-beta.10"
   dependencies:
-    "@vechain/connex-driver": ^2.0.12
-    "@vechain/connex-framework": ^2.0.12
-    "@vechain/web3-providers-connex": ^1.1.2
-    debug: ^4.3.4
-    ethers: ^6.7.1
-    pino: 8.14.1
-    pino-pretty: 9.4.0
-    thor-devkit: ^2.0.6
-  peerDependencies:
-    hardhat: ^2.12.7
-  checksum: afc9fff50f64c6a720c3145d040706bade951795b451bc4b4485996d8c3eb6f503ecc2a9d094b2b7d79ffd3169d3400a10d2b13746b9acb15f8b6ca10772564e
+    "@vechain/sdk-errors": 1.0.0-beta.10
+  checksum: dd87133cee63b3751c4a533c7c5bdcad4ec9954a4c686de9ead8d47517d15402e41a42a29ab53c540e4c65be7b25f2bd8ea4a8af41fbb3c35ffff0510eddf03c
   languageName: node
   linkType: hard
 
-"@vechain/hardhat-web3@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@vechain/hardhat-web3@npm:0.1.4"
-  peerDependencies:
-    "@nomiclabs/hardhat-web3": ^2.0.0
-    "@vechain/hardhat-vechain": ^0.1.4
-    hardhat: ^2.12.7
-    web3: ^1.0.0-beta.36
-  checksum: 4fd85e5593b32d7cbf2f8ae33d16c3db52df275d90db3ea4f902b2b71c72d0bda649cc49f06790cf463e17fc7d26ab423007659dc0a4c976be66a65b03363905
-  languageName: node
-  linkType: hard
-
-"@vechain/web3-providers-connex@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@vechain/web3-providers-connex@npm:1.1.2"
+"@vechain/sdk-network@npm:1.0.0-beta.10":
+  version: 1.0.0-beta.10
+  resolution: "@vechain/sdk-network@npm:1.0.0-beta.10"
   dependencies:
-    "@vechain/connex-types": ^2.0.2
-    eventemitter3: ^4.0.4
-    thor-devkit: ^2.0.4
-    web3-utils: ^1.7.3
-  peerDependencies:
-    ethers: ^6.7.1
-  checksum: 3b9d49989ff02ab7b4cecf3173d92afc16320b46c4ced060e2ac578253b6d296a1477df176854f8c3a4e3c5f1fdc95a3139e0bfc55c7a7cc1b774569e879c2c0
+    "@types/ws": ^8.5.10
+    "@vechain/sdk-core": 1.0.0-beta.10
+    "@vechain/sdk-errors": 1.0.0-beta.10
+    "@vechain/sdk-logging": 1.0.0-beta.10
+    axios: ^1.7.2
+  checksum: fa368e90e7974c7dfe8e503696e8057a75677f44aad747769d411e04d537e9c489e3a1bba85b8c602fd5e27ba816c167d17cef7e1a0ad3220e023614cdcffa8f
   languageName: node
   linkType: hard
 
@@ -1943,15 +1986,6 @@ __metadata:
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
   checksum: 0e994ad2aa6575f94670d8a2149afe94465de9cedaaaac364e7fb43a40c3691c980ff74899f682f4ca58fa96b4cbd7421a015d3a6defe43a442117d7821a2f36
-  languageName: node
-  linkType: hard
-
-"abort-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "abort-controller@npm:3.0.0"
-  dependencies:
-    event-target-shim: ^5.0.0
-  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
   languageName: node
   linkType: hard
 
@@ -2339,13 +2373,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"atomic-sleep@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "atomic-sleep@npm:1.0.0"
-  checksum: b95275afb2f80732f22f43a60178430c468906a415a7ff18bcd0feeebc8eec3930b51250aeda91a476062a90e07132b43a1794e8d8ffcf9b650e8139be75fa36
-  languageName: node
-  linkType: hard
-
 "atomically@npm:^1.7.0":
   version: 1.7.0
   resolution: "atomically@npm:1.7.0"
@@ -2377,6 +2404,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: e28d67b2d9134cb4608c44d8068b0678cfdccc652742e619006f27264a30c7aba13b2cd19c6f1f52ae195b5232734925928fb192d5c85feea7edd2f273df206d
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: e457e2b0ab748504621f6fa6609074ac08c824bf0881592209dfa15098ece7e88495300e02cd22ba50b3468fd712fe687e629dcb03d6a3f6a51989727405aedf
   languageName: node
   linkType: hard
 
@@ -2417,10 +2455,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^7.2.1":
-  version: 7.2.1
-  resolution: "bignumber.js@npm:7.2.1"
-  checksum: c4eab705fb3293170f248f13f38a06d24591710864632f78b1637d361feaf07ce782cc6ea23c6984c8ddb030ad1883b813a251448527d55650b403e6f2cc7e67
+"bignumber.js@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "bignumber.js@npm:9.1.2"
+  checksum: 582c03af77ec9cb0ebd682a373ee6c66475db94a4325f92299621d544aa4bd45cb45fd60001610e94aef8ae98a0905fa538241d9638d4422d57abbeeac6fadaf
   languageName: node
   linkType: hard
 
@@ -2442,7 +2480,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:^1.1.0, blakejs@npm:^1.1.2":
+"blakejs@npm:^1.1.0, blakejs@npm:^1.2.1":
   version: 1.2.1
   resolution: "blakejs@npm:1.2.1"
   checksum: d699ba116cfa21d0b01d12014a03e484dd76d483133e6dc9eb415aa70a119f08beb3bcefb8c71840106a00b542cba77383f8be60cd1f0d4589cb8afb922eefbe
@@ -2456,7 +2494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9, bn.js@npm:^4.4.0":
+"bn.js@npm:^4.11.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
@@ -2986,13 +3024,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.7":
-  version: 2.0.20
-  resolution: "colorette@npm:2.0.20"
-  checksum: 0c016fea2b91b733eb9f4bcdb580018f52c0bc0979443dad930e5037a968237ac53d9beb98e218d2e9235834f8eebce7f8e080422d6194e957454255bde71d3d
-  languageName: node
-  linkType: hard
-
 "colors@npm:1.4.0, colors@npm:^1.1.2":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
@@ -3198,15 +3229,13 @@ __metadata:
     "@types/chai": ^4.2.0
     "@types/mocha": ">=9.1.0"
     "@types/node": ">=16.0.0"
-    "@vechain/hardhat-ethers": ^0.1.6
-    "@vechain/hardhat-vechain": ^0.1.7
-    "@vechain/hardhat-web3": ^0.1.4
-    "@vechain/web3-providers-connex": ^1.1.2
+    "@vechain/sdk-hardhat-plugin": ^1.0.0-beta.10
     chai: ^4.2.0
     dotenv: ^16.4.5
     ethers: ^6.4.0
     hardhat: ^2.19.4
-    hardhat-deploy: "npm:@vechain.energy/hardhat-deploy@latest"
+    hardhat-deploy: ^0.12.4
+    hardhat-deploy-ethers: ^0.4.2
     hardhat-gas-reporter: ^1.0.8
     solidity-coverage: ^0.8.0
     ts-node: ">=8.0.0"
@@ -3257,13 +3286,6 @@ __metadata:
   version: 0.2.2
   resolution: "cuint@npm:0.2.2"
   checksum: b8127a93a7f16ce120ffcb22108014327c9808b258ee20e7dbb4c6740d7cb0f0c12d18a054eb716b0f2470090666abaae8a082d3cd5ef0e94fa447dd155842c4
-  languageName: node
-  linkType: hard
-
-"dateformat@npm:^4.6.3":
-  version: 4.6.3
-  resolution: "dateformat@npm:4.6.3"
-  checksum: c3aa0617c0a5b30595122bc8d1bee6276a9221e4d392087b41cbbdf175d9662ae0e50d0d6dcdf45caeac5153c4b5b0844265f8cd2b2245451e3da19e39e3b65d
   languageName: node
   linkType: hard
 
@@ -3507,6 +3529,21 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.5":
+  version: 6.5.5
+  resolution: "elliptic@npm:6.5.5"
+  dependencies:
+    bn.js: ^4.11.9
+    brorand: ^1.1.0
+    hash.js: ^1.0.0
+    hmac-drbg: ^1.0.1
+    inherits: ^2.0.4
+    minimalistic-assert: ^1.0.1
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: ec9105e4469eb3b32b0ee2579756c888ddf3f99d259aa0d65fccb906ee877768aaf8880caae73e3e669c9a4adeb3eb1945703aa974ec5000d2d33a239f4567eb
   languageName: node
   linkType: hard
 
@@ -3859,7 +3896,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.7.0, ethers@npm:^5.7.1, ethers@npm:^5.7.2":
+"ethers@npm:6.12.1":
+  version: 6.12.1
+  resolution: "ethers@npm:6.12.1"
+  dependencies:
+    "@adraffy/ens-normalize": 1.10.1
+    "@noble/curves": 1.2.0
+    "@noble/hashes": 1.3.2
+    "@types/node": 18.15.13
+    aes-js: 4.0.0-beta.5
+    tslib: 2.4.0
+    ws: 8.5.0
+  checksum: ddf398c91f584b9e643740ec17a9c82b4a1c4ea3fb6efd00f1a043b89d1ec6f9427aa80894f75850ee805722e91b8d054bce18579a2c621226302c096774df90
+  languageName: node
+  linkType: hard
+
+"ethers@npm:^5.7.0, ethers@npm:^5.7.1, ethers@npm:^5.7.2, ethers@npm:~5.7.0":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -3897,7 +3949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^6.4.0, ethers@npm:^6.7.1":
+"ethers@npm:^6.4.0":
   version: 6.9.2
   resolution: "ethers@npm:6.9.2"
   dependencies:
@@ -3929,27 +3981,6 @@ __metadata:
     is-hex-prefixed: 1.0.0
     strip-hex-prefix: 1.0.0
   checksum: 1f42959e78ec6f49889c49c8a98639e06f52a15966387dd39faf2930db48663d026efb7db2702dcffe7f2a99c4a0144b7ce784efdbf733f4077aae95de76d65f
-  languageName: node
-  linkType: hard
-
-"event-target-shim@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "event-target-shim@npm:5.0.1"
-  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^4.0.4":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -4021,13 +4052,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-copy@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "fast-copy@npm:3.0.1"
-  checksum: 5496b5cf47df29eea479deef03b6b7188626a2cbc356b3015649062846729de6f1a9f555f937e772da8feae0a1231fab13096ed32424b2d61e4d065abc9969fe
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.1":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -4059,20 +4083,6 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
-  languageName: node
-  linkType: hard
-
-"fast-redact@npm:^3.1.1":
-  version: 3.3.0
-  resolution: "fast-redact@npm:3.3.0"
-  checksum: 3f7becc70a5a2662a9cbfdc52a4291594f62ae998806ee00315af307f32d9559dbf512146259a22739ee34401950ef47598c1f4777d33b0ed5027203d67f549c
-  languageName: node
-  linkType: hard
-
-"fast-safe-stringify@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1"
-  checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
   languageName: node
   linkType: hard
 
@@ -4179,6 +4189,16 @@ __metadata:
     debug:
       optional: true
   checksum: 5ca49b5ce6f44338cbfc3546823357e7a70813cecc9b7b768158a1d32c1e62e7407c944402a918ea8c38ae2e78266312d617dc68783fac502cbb55e1047b34ec
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 
@@ -4538,19 +4558,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.0":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^5.0.1
-    once: ^1.3.0
-  checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
-  languageName: node
-  linkType: hard
-
 "global-dirs@npm:^3.0.0":
   version: 3.0.1
   resolution: "global-dirs@npm:3.0.1"
@@ -4658,9 +4665,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat-deploy@npm:@vechain.energy/hardhat-deploy@latest":
-  version: 0.11.46
-  resolution: "@vechain.energy/hardhat-deploy@npm:0.11.46"
+"hardhat-deploy-ethers@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "hardhat-deploy-ethers@npm:0.4.2"
+  peerDependencies:
+    "@nomicfoundation/hardhat-ethers": ^3.0.2
+    hardhat: ^2.16.0
+    hardhat-deploy: ^0.12.0
+  checksum: 38c06f6b1d482cff92f31f1daf4cc4b6be943e1f62148e29cdddfc481d040470b9d6f233e0d61517fd02cc259f9f77ebd4512ea79624a893c72c90d70eff3f65
+  languageName: node
+  linkType: hard
+
+"hardhat-deploy@npm:^0.12.4":
+  version: 0.12.4
+  resolution: "hardhat-deploy@npm:0.12.4"
   dependencies:
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/abstract-signer": ^5.7.0
@@ -4685,8 +4703,8 @@ __metadata:
     match-all: ^1.2.6
     murmur-128: ^0.2.1
     qs: ^6.9.4
-    zksync-web3: ^0.14.3
-  checksum: 2e3036a44b2bb5128e66f0834d3b51ce345e2cf580526080cf9e0c7b820dffb8b82ffb069ffeef75e0ec4ed44714c3be89b8bfc33ddefdb856eec319243abb48
+    zksync-ethers: ^5.0.0
+  checksum: 995a20a7ae8d10d2b961690e0903cd2a4a07198bc3d20a15d4734f2d9aade261b6f0ffb9e01b8fc013de34b687e401ed0c90dfc4d592571576f133ce8cbf3003
   languageName: node
   linkType: hard
 
@@ -4854,16 +4872,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:1.1.3":
-  version: 1.1.3
-  resolution: "hash.js@npm:1.1.3"
-  dependencies:
-    inherits: ^2.0.3
-    minimalistic-assert: ^1.0.0
-  checksum: 93de6f178bf71feee38f66868a57ecb5602d937c1ccd69951b0bfec1488813b6afdbb4a81ddb2c62488c419b4a35af352298b006f14c9cfbf5b872c4191b657f
-  languageName: node
-  linkType: hard
-
 "hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
@@ -4896,16 +4904,6 @@ __metadata:
   version: 0.2.7
   resolution: "heap@npm:0.2.7"
   checksum: b0f3963a799e02173f994c452921a777f2b895b710119df999736bfed7477235c2860c423d9aea18a9f3b3d065cb1114d605c208cfcb8d0ac550f97ec5d28cb0
-  languageName: node
-  linkType: hard
-
-"help-me@npm:^4.0.1":
-  version: 4.2.0
-  resolution: "help-me@npm:4.2.0"
-  dependencies:
-    glob: ^8.0.0
-    readable-stream: ^3.6.0
-  checksum: 6548acba10dd79ebfc93f0d739c4cb2f32f7932c8d87b091992f3a0f844706263415eab81be015aed4ab874154232beb666920d7e280502c6bba29a40cde343e
   languageName: node
   linkType: hard
 
@@ -5484,15 +5482,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-ws@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "isomorphic-ws@npm:4.0.1"
-  peerDependencies:
-    ws: "*"
-  checksum: d7190eadefdc28bdb93d67b5f0c603385aaf87724fa2974abb382ac1ec9756ed2cfb27065cbe76122879c2d452e2982bc4314317f3d6c737ddda6c047328771a
-  languageName: node
-  linkType: hard
-
 "jackspeak@npm:^2.3.5":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -5503,13 +5492,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 57d43ad11eadc98cdfe7496612f6bbb5255ea69fe51ea431162db302c2a11011642f50cfad57288bd0aea78384a0612b16e131944ad8ecd09d619041c8531b54
-  languageName: node
-  linkType: hard
-
-"joycon@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "joycon@npm:3.1.1"
-  checksum: 8003c9c3fc79c5c7602b1c7e9f7a2df2e9916f046b0dbad862aa589be78c15734d11beb9fe846f5e06138df22cb2ad29961b6a986ba81c4920ce2b15a7f11067
   languageName: node
   linkType: hard
 
@@ -5524,13 +5506,6 @@ __metadata:
   version: 4.4.2
   resolution: "js-sdsl@npm:4.4.2"
   checksum: ba705adc1788bf3c6f6c8e5077824f2bb4f0acab5a984420ce5cc492c7fff3daddc26335ad2c9a67d4f5e3241ec790f9e5b72a625adcf20cf321d2fd85e62b8b
-  languageName: node
-  linkType: hard
-
-"js-sha3@npm:0.5.7":
-  version: 0.5.7
-  resolution: "js-sha3@npm:0.5.7"
-  checksum: 973a28ea4b26cc7f12d2ab24f796e24ee4a71eef45a6634a052f6eb38cf8b2333db798e896e6e094ea6fa4dfe8e42a2a7942b425cf40da3f866623fd05bb91ea
   languageName: node
   linkType: hard
 
@@ -6050,15 +6025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^9.0.1":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
@@ -6477,13 +6443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-exit-leak-free@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "on-exit-leak-free@npm:2.1.2"
-  checksum: 6ce7acdc7b9ceb51cf029b5239cbf41937ee4c8dcd9d4e475e1777b41702564d46caa1150a744e00da0ac6d923ab83471646a39a4470f97481cf6e2d8d253c3f
-  languageName: node
-  linkType: hard
-
 "once@npm:1.x, once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -6770,78 +6729,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-abstract-transport@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "pino-abstract-transport@npm:1.1.0"
-  dependencies:
-    readable-stream: ^4.0.0
-    split2: ^4.0.0
-  checksum: cc84caabee5647b5753ae484d5f63a1bca0f6e1791845e2db2b6d830a561c2b5dd1177720f68d78994c8a93aecc69f2729e6ac2bc871a1bf5bb4b0ec17210668
-  languageName: node
-  linkType: hard
-
-"pino-abstract-transport@npm:v1.0.0":
-  version: 1.0.0
-  resolution: "pino-abstract-transport@npm:1.0.0"
-  dependencies:
-    readable-stream: ^4.0.0
-    split2: ^4.0.0
-  checksum: 05dd0eda52dd99fd204b39fe7b62656744b63e863bc052cdd5105d25f226a236966d0a46e39a1ace4838f6e988c608837ff946d2d0bc92835ca7baa0a3bff8d8
-  languageName: node
-  linkType: hard
-
-"pino-pretty@npm:9.4.0":
-  version: 9.4.0
-  resolution: "pino-pretty@npm:9.4.0"
-  dependencies:
-    colorette: ^2.0.7
-    dateformat: ^4.6.3
-    fast-copy: ^3.0.0
-    fast-safe-stringify: ^2.1.1
-    help-me: ^4.0.1
-    joycon: ^3.1.1
-    minimist: ^1.2.6
-    on-exit-leak-free: ^2.1.0
-    pino-abstract-transport: ^1.0.0
-    pump: ^3.0.0
-    readable-stream: ^4.0.0
-    secure-json-parse: ^2.4.0
-    sonic-boom: ^3.0.0
-    strip-json-comments: ^3.1.1
-  bin:
-    pino-pretty: bin.js
-  checksum: 4870d44879048219003b0c6f28181ca871e62c1d9679b07b3f3d703e961284b5b0df495e4be95954a0e467ded34f2323bc9cf3280c3a143311b364a733a08e03
-  languageName: node
-  linkType: hard
-
-"pino-std-serializers@npm:^6.0.0":
-  version: 6.2.2
-  resolution: "pino-std-serializers@npm:6.2.2"
-  checksum: aeb0662edc46ec926de9961ed4780a4f0586bb7c37d212cd469c069639e7816887a62c5093bc93f260a4e0900322f44fc8ab1343b5a9fa2864a888acccdb22a4
-  languageName: node
-  linkType: hard
-
-"pino@npm:8.14.1":
-  version: 8.14.1
-  resolution: "pino@npm:8.14.1"
-  dependencies:
-    atomic-sleep: ^1.0.0
-    fast-redact: ^3.1.1
-    on-exit-leak-free: ^2.1.0
-    pino-abstract-transport: v1.0.0
-    pino-std-serializers: ^6.0.0
-    process-warning: ^2.0.0
-    quick-format-unescaped: ^4.0.3
-    real-require: ^0.2.0
-    safe-stable-stringify: ^2.3.1
-    sonic-boom: ^3.1.0
-    thread-stream: ^2.0.0
-  bin:
-    pino: bin.js
-  checksum: 72dcae8f550d375695bb8745f11b30c42aaa20d0bcab8f546ca5af0684d784453850949fe1b244206793e813a46d72cbbf0dda8aed2cee86e9491ba44a643e3e
-  languageName: node
-  linkType: hard
-
 "pkg-up@npm:^3.1.0":
   version: 3.1.0
   resolution: "pkg-up@npm:3.1.0"
@@ -6885,20 +6772,6 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
-  languageName: node
-  linkType: hard
-
-"process-warning@npm:^2.0.0":
-  version: 2.3.2
-  resolution: "process-warning@npm:2.3.2"
-  checksum: cbeddc85d3963eccd6578b1eea5ba981383d1ec688d6e4ba5bf0ca6662d094c024b44dfcb1c530662c7694b68fe09fd95fa0269a1309090d793008f4553e7784
-  languageName: node
-  linkType: hard
-
-"process@npm:^0.11.10":
-  version: 0.11.10
-  resolution: "process@npm:0.11.10"
-  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
   languageName: node
   linkType: hard
 
@@ -6981,13 +6854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quick-format-unescaped@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "quick-format-unescaped@npm:4.0.4"
-  checksum: 7bc32b99354a1aa46c089d2a82b63489961002bb1d654cee3e6d2d8778197b68c2d854fd23d8422436ee1fdfd0abaddc4d4da120afe700ade68bd357815b26fd
-  languageName: node
-  linkType: hard
-
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -7049,32 +6915,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^4.0.0":
-  version: 4.5.2
-  resolution: "readable-stream@npm:4.5.2"
-  dependencies:
-    abort-controller: ^3.0.0
-    buffer: ^6.0.3
-    events: ^3.3.0
-    process: ^0.11.10
-    string_decoder: ^1.3.0
-  checksum: c4030ccff010b83e4f33289c535f7830190773e274b3fcb6e2541475070bdfd69c98001c3b0cb78763fc00c8b62f514d96c2b10a8bd35d5ce45203a25fa1d33a
-  languageName: node
-  linkType: hard
-
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
   dependencies:
     picomatch: ^2.2.1
   checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
-  languageName: node
-  linkType: hard
-
-"real-require@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "real-require@npm:0.2.0"
-  checksum: fa060f19f2f447adf678d1376928c76379dce5f72bd334da301685ca6cdcb7b11356813332cc243c88470796bc2e2b1e2917fc10df9143dd93c2ea608694971d
   languageName: node
   linkType: hard
 
@@ -7290,7 +7136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rlp@npm:^2.0.0, rlp@npm:^2.2.3, rlp@npm:^2.2.4":
+"rlp@npm:^2.2.3, rlp@npm:^2.2.4":
   version: 2.2.7
   resolution: "rlp@npm:2.2.7"
   dependencies:
@@ -7408,13 +7254,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scrypt-js@npm:2.0.4":
-  version: 2.0.4
-  resolution: "scrypt-js@npm:2.0.4"
-  checksum: 679e8940953ebbef40863bfcc58f1d3058d4b7af0ca9bd8062d8213c30e14db59c6ebfc82a85fbd3b90b6d46b708be4c53b9c4bb200b6f50767dc08a846315a9
-  languageName: node
-  linkType: hard
-
 "scrypt-js@npm:3.0.1, scrypt-js@npm:^3.0.0":
   version: 3.0.1
   resolution: "scrypt-js@npm:3.0.1"
@@ -7431,13 +7270,6 @@ __metadata:
     node-gyp: latest
     node-gyp-build: ^4.2.0
   checksum: 21e219adc0024fbd75021001358780a3cc6ac21273c3fcaef46943af73969729709b03f1df7c012a0baab0830fb9a06ccc6b42f8d50050c665cb98078eab477b
-  languageName: node
-  linkType: hard
-
-"secure-json-parse@npm:^2.4.0":
-  version: 2.7.0
-  resolution: "secure-json-parse@npm:2.7.0"
-  checksum: d9d7d5a01fc6db6115744ba23cf9e67ecfe8c524d771537c062ee05ad5c11b64c730bc58c7f33f60bd6877f96b86f0ceb9ea29644e4040cb757f6912d4dd6737
   languageName: node
   linkType: hard
 
@@ -7508,13 +7340,6 @@ __metadata:
     functions-have-names: ^1.2.3
     has-property-descriptors: ^1.0.0
   checksum: 4975d17d90c40168eee2c7c9c59d023429f0a1690a89d75656306481ece0c3c1fb1ebcc0150ea546d1913e35fbd037bace91372c69e543e51fc5d1f31a9fa126
-  languageName: node
-  linkType: hard
-
-"setimmediate@npm:1.0.4":
-  version: 1.0.4
-  resolution: "setimmediate@npm:1.0.4"
-  checksum: 1d3726183ade73fa1c83bd562b05ae34e97802229d5b9292cde7ed03846524f04eb0fdd2131cc159103e3a7afb7c4e958b35bf960e3c4846fa50d94a3278be6f
   languageName: node
   linkType: hard
 
@@ -7739,15 +7564,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sonic-boom@npm:^3.0.0, sonic-boom@npm:^3.1.0":
-  version: 3.8.0
-  resolution: "sonic-boom@npm:3.8.0"
-  dependencies:
-    atomic-sleep: ^1.0.0
-  checksum: c21ece61a0cabb78db96547aecb4e9086eba2db2d53030221ed07215bfda2d25bb02906366ea2584cbe73d236dd7dd109122d3d7287914b76a9630e0a36ad819
-  languageName: node
-  linkType: hard
-
 "source-map-support@npm:^0.5.13, source-map-support@npm:^0.5.16":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -7771,13 +7587,6 @@ __metadata:
   dependencies:
     amdefine: ">=0.0.4"
   checksum: 95fe800c3a93f8c0b9516c033bfc75f2678e27d2e6c0b23ae222f5ddc4afa0a39bd0be15d1c0a1e766d388f3761cc854a053a4330f49242e6045e1a4f9dc0e26
-  languageName: node
-  linkType: hard
-
-"split2@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "split2@npm:4.2.0"
-  checksum: 05d54102546549fe4d2455900699056580cca006c0275c334611420f854da30ac999230857a85fdd9914dc2109ae50f80fda43d2a445f2aa86eccdc1dfce779d
   languageName: node
   linkType: hard
 
@@ -7892,7 +7701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
+"string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -7960,7 +7769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
@@ -8099,30 +7908,6 @@ __metadata:
     promise: ^8.0.0
     qs: ^6.4.0
   checksum: a24a4fc95dd8591966bf3752f024f5cd4d53c2b2c29b23b4e40c3322df6a432d939bc17b589d8e9d760b90e92ab860f6f361a4dfcfe3542019e1615fb51afccc
-  languageName: node
-  linkType: hard
-
-"thor-devkit@npm:^2.0.4, thor-devkit@npm:^2.0.5, thor-devkit@npm:^2.0.6":
-  version: 2.0.9
-  resolution: "thor-devkit@npm:2.0.9"
-  dependencies:
-    "@vechain/ethers": ^4.0.27-5
-    bignumber.js: ^7.2.1
-    blakejs: ^1.1.2
-    elliptic: 6.5.4
-    fast-json-stable-stringify: ^2.1.0
-    js-sha3: 0.5.7
-    rlp: ^2.0.0
-  checksum: 88fb41a8c66b4334c292742b0e737af519ee7d94054b3a82e489d3ef79584263571b299bb6b9d777c37581f4d3b76862c22ce87f5684fd39e71d8da0d9e91405
-  languageName: node
-  linkType: hard
-
-"thread-stream@npm:^2.0.0":
-  version: 2.4.1
-  resolution: "thread-stream@npm:2.4.1"
-  dependencies:
-    real-require: ^0.2.0
-  checksum: 8b28e11eab2f805f963e6b6b23afab5523079575c4fc79c16eb29aa1c13d7931289762ebbc1268b3373d3f35ce795bd291df8e2d51eb45779ecaaecd06873459
   languageName: node
   linkType: hard
 
@@ -8586,13 +8371,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:2.0.1":
-  version: 2.0.1
-  resolution: "uuid@npm:2.0.1"
-  checksum: e129e494e33cededdfc2cefbd63da966344b873bbfd3373a311b0acc2e7ab53d68b2515879444898867d84b863e44939e852484b9f3a54c4fd86d985a7dadb8d
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
@@ -8609,13 +8387,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator-ts@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "validator-ts@npm:0.9.1"
-  checksum: e699ff8d2ccaac05d7da6d3abcf21461b4b95e00172f4cdaee55ca4d545020b24d4a1cec0e8d6700e6e28001b054c3949bd6ea112da510c0d85b125806b7d627
-  languageName: node
-  linkType: hard
-
 "wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -8625,7 +8396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-utils@npm:^1.3.6, web3-utils@npm:^1.7.3":
+"web3-utils@npm:^1.3.6":
   version: 1.10.3
   resolution: "web3-utils@npm:1.10.3"
   dependencies:
@@ -8869,7 +8640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.1.0, ws@npm:^7.4.6":
+"ws@npm:^7.4.6":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
   peerDependencies:
@@ -8888,13 +8659,6 @@ __metadata:
   version: 4.0.0
   resolution: "xdg-basedir@npm:4.0.0"
   checksum: 0073d5b59a37224ed3a5ac0dd2ec1d36f09c49f0afd769008a6e9cd3cd666bd6317bd1c7ce2eab47e1de285a286bad11a9b038196413cd753b79770361855f3c
-  languageName: node
-  linkType: hard
-
-"xmlhttprequest@npm:1.8.0":
-  version: 1.8.0
-  resolution: "xmlhttprequest@npm:1.8.0"
-  checksum: c891cf0d7884b4f5cce835aa01f1965727cd352cbd2d7a2e0605bf11ec99ae2198364cca54656ec8b2581a5704dee6c2bf9911922a0ff2a71b613455d32e81b7
   languageName: node
   linkType: hard
 
@@ -8983,11 +8747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zksync-web3@npm:^0.14.3":
-  version: 0.14.4
-  resolution: "zksync-web3@npm:0.14.4"
+"zksync-ethers@npm:^5.0.0":
+  version: 5.7.2
+  resolution: "zksync-ethers@npm:5.7.2"
+  dependencies:
+    ethers: ~5.7.0
   peerDependencies:
-    ethers: ^5.7.0
-  checksum: f702a3437f48a8d42c4bb35b8dd13671a168aadfc4e23ce723d62959220ccb6bf9c529c60331fe5b91afaa622147c6a37490551474fe3e35c06ac476524b5160
+    ethers: ~5.7.0
+  checksum: 3b23de5bf258149449d7f2e548c84d3b0552c3077aef769844221f229631ae1f08e6739900047ae618193498e0a640d88f215d849043bf4fca14e067cce652db
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR removes the current use of a patched module by relying purely on the new vechain sdk. In addition it adds examples and support for hardhat-deploy-ethers, making contract interaction easier.